### PR TITLE
Fix #36

### DIFF
--- a/addons/signal_lens/editor/signal_lens_editor_panel.gd
+++ b/addons/signal_lens/editor/signal_lens_editor_panel.gd
@@ -206,7 +206,7 @@ func draw_node_data(data: Array):
 						graph_edit.add_child(target_callables_node)
 						target_callables_node.position_offset += Vector2(250, 0)
 					else:
-						target_callables_node = get_node(target_node_name + " (Callables)")
+						target_callables_node = graph_edit.get_node(target_node_name + " (Callables)")
 					create_button_slot(callable_method, target_callables_node, Direction.LEFT, slot_color)
 					graph_edit.connect_node(target_node.name, current_signal_index, target_callables_node.name, target_callables_node.get_child_count() - 1)
 				else:


### PR DESCRIPTION
This change can fix #36, issue information:
- Error is shown when a node has more than one connection to itself callables, when line 209 in execute
- In line 209, `target_callables_node = get_node(target_node_name + " (Callables)")` (old code) was trying to find a button for target node callables in panel instead of searching for it in graph edit node
- This bug makes `target_callables_node` null and causes #36
- Also, when errors are displayed, graph generation stops, which will no longer happen once the error is resolved with this change