### PR TITLE
Rename SignalLensLogger name-collide for Godot 4.5

### DIFF
--- a/addons/signal_lens/editor/logger/logger.gd
+++ b/addons/signal_lens/editor/logger/logger.gd
@@ -1,5 +1,5 @@
 @tool
-class_name Logger
+class_name SignalLensLogger
 extends Control
 
 const MAX_LOGS := 1000

--- a/addons/signal_lens/editor/signal_lens_editor_panel.tscn
+++ b/addons/signal_lens/editor/signal_lens_editor_panel.tscn
@@ -134,7 +134,7 @@ keep_emissions_checkbox = NodePath("EditorPanel/MainButtonsContainer/HBoxContain
 emission_speed_slider = NodePath("EditorPanel/MainButtonsContainer/HBoxContainer2/EmissionSpeedContainer/EmissionSpeedSlider")
 emission_speed_icon = NodePath("EditorPanel/MainButtonsContainer/HBoxContainer2/EmissionSpeedContainer/EmissionSpeedIcon")
 connection_opacity_icon = NodePath("EditorPanel/MainButtonsContainer/HBoxContainer2/ConnectionOpacityContainer/ConnectionOpacityIcon")
-logger = NodePath("EditorPanel/Logger")
+logger = NodePath("EditorPanel/SignalLensLogger")
 
 [node name="EditorPanel" type="PanelContainer" parent="."]
 self_modulate = Color(1, 1, 1, 0)
@@ -305,7 +305,7 @@ Access the plugin's repository on Github to report issues, suggest features and 
 icon = SubResource("ImageTexture_0xhoi")
 flat = true
 
-[node name="Logger" parent="EditorPanel" instance=ExtResource("3_v6bl3")]
+[node name="SignalLensLogger" parent="EditorPanel" instance=ExtResource("3_v6bl3")]
 visible = false
 layout_mode = 2
 theme_override_constants/margin_top = 55

--- a/addons/signal_lens/editor/signal_lens_logger.tscn
+++ b/addons/signal_lens/editor/signal_lens_logger.tscn
@@ -71,7 +71,7 @@ image = SubResource("Image_5voln")
 [sub_resource type="StyleBoxLine" id="StyleBoxLine_v6bl3"]
 color = Color(0.244776, 0.244776, 0.244776, 1)
 
-[node name="Logger" type="MarginContainer" node_paths=PackedStringArray("log_container", "copy_button", "clear_button", "v_split_container", "h_split_container", "log_scroll", "counter_label")]
+[node name="SignalLensLogger" type="MarginContainer" node_paths=PackedStringArray("log_container", "copy_button", "clear_button", "v_split_container", "h_split_container", "log_scroll", "counter_label")]
 custom_minimum_size = Vector2(400, 0)
 anchors_preset = 9
 anchor_bottom = 1.0


### PR DESCRIPTION
Fixes https://github.com/yannlemos/Signal-Lens/issues/43

It collides with the Godot 4.5 class_name "Logger": https://docs.godotengine.org/en/latest/classes/class_logger.html

Works now, at least all the things I tried in this video :

https://github.com/user-attachments/assets/f248af4e-99db-4e8c-b77f-9933b04d1fb7

